### PR TITLE
vhdl: fixing counter incrementation

### DIFF
--- a/2-FPGA-designs-with-VHDL/Codes-VHDL/Chapter-Finite-state-machines/VHDLCodes/counterEx.vhd
+++ b/2-FPGA-designs-with-VHDL/Codes-VHDL/Chapter-Finite-state-machines/VHDLCodes/counterEx.vhd
@@ -19,13 +19,13 @@ end entity;
 architecture arch of counterEx is 
 	type stateType_moore is (start_moore, count_moore);
 	signal state_moore_reg, state_moore_next : stateType_moore;
-	signal count_moore_reg, count_moore_next : unsigned(N-1 downto 0);
+	signal count_moore_reg, count_moore_next : integer;
 begin 
 	process(clk, reset)
 	begin 
 		if reset = '1' then
 			state_moore_reg <= start_moore;
-			count_moore_reg <= (others => '0');
+			count_moore_reg <= 0;
 		elsif rising_edge(clk) then
 			state_moore_reg <= state_moore_next;
 			count_moore_reg <= count_moore_next;
@@ -36,11 +36,11 @@ begin
 	begin 
 		case state_moore_reg is
 			when start_moore =>
-				count_moore_next <= (others => '0');
+				count_moore_next <= 0;
 				state_moore_next <= count_moore;
 			when count_moore =>
 				count_moore_next <= count_moore_reg  + 1;
-				if (count_moore_reg  + 1) = M - 1 then
+				if (count_moore_reg = M - 1) then
 					state_moore_next <= start_moore;
 				else
 					state_moore_next <= count_moore;


### PR DESCRIPTION
Rebuilding the examples, I had issues at incrementation of a vector type.
Actually counting and carry over did not work auto-magically for me. First I
had an error message, bringing it to work it did not count as expected.

Another item for me was the check "(COUNT_MOORE_REG +1) = M - 1", does this
actually make sense, or do I missunderstand it, in my opinion it should be
either sustraction or addition by one. Performing both neutralizes itself, or
am I wrong?

The patch should is my approach to fix this issue. Please, give it a chance and
verify if the patch works out. I would really appreciate contribution to your
project.

---

Dear Mr. Meher Krishna Patel! I am highly impressed of your VHDL tutorial! I'm often re-reading your examples and explanations when on my own setups. I hope it is ok, to use one or the other idea and provide reference to your VHDL tutorial as origin (it's for my own hobby and not of commercial use)? 
Currently I'm playing around with NIOS Setups, and I probably have more questions than understanding. May I approach you and ask some questions directly? Probably you're a very busy person and I don't want to bother you with probably very stupid problems. Anyway, thank you so much for your tutorial! lotophagon@protonmail.com